### PR TITLE
Avoid negative delay when the program was paused

### DIFF
--- a/src/main/java/com/noenv/cronutils/impl/CronSchedulerImpl.java
+++ b/src/main/java/com/noenv/cronutils/impl/CronSchedulerImpl.java
@@ -74,6 +74,10 @@ public class CronSchedulerImpl implements CronScheduler, Handler<Long> {
 
   private long getNextDelay(final ZonedDateTime time) {
     final Duration timeToNextExecution = Duration.between(time, executionTime);
-    return timeToNextExecution.toMillis();
+    // If the program is paused for long enough (debugging) and a task is scheduled to run frequently,
+    // the newly calculated execution time can be less than current time, that could cause negative value here.
+    // With this solution the missed runs will happen in a burst after the pause until it catches up.
+    // (Vertx does not allow to set a timer with delay < 1 ms)
+    return Math.max(1, timeToNextExecution.toMillis());
   }
 }


### PR DESCRIPTION
**Symptom**: Sometimes "Cannot schedule a timer with delay < 1 ms" error occurs while debugging.
**How to reproduce:** Setup a scheduled task running every sec, and start a debugging session, put a breakpoint(can be unrelated parts of the code), make the breakpoint hit, then wait few seconds, then let the program to continue. You will see this exception, and it will never schedule a new task again:
```
java.lang.IllegalArgumentException: Cannot schedule a timer with delay < 1 ms 
	at io.vertx.core.impl.VertxImpl.scheduleTimeout(VertxImpl.java:494)
	at io.vertx.core.impl.VertxImpl.setTimer(VertxImpl.java:341)
	at com.noenv.cronutils.impl.CronSchedulerImpl.lambda$handle$1(CronSchedulerImpl.java:70)
```
**Explanation**:
It looks like at https://github.com/NoEnv/vertx-cronutils/blob/f200cadcfd826ca48dcf070b5ed8e7cbe5042e3f/src/main/java/com/noenv/cronutils/impl/CronSchedulerImpl.java#L67
the next execution is calculated from when the current execution should have happened. That is problematic when the program is paused for some time and the callback is delayed (breakpoint, long GC pause) in case of frequently occurring task. In that case the calculated next execution is still in the past, which makes it set the timer up with negative values.
**Possible solutions:**
1) Use expression.nextExecution(now) instead of expression.nextExecution(executionTime).
When having a task occurring like every sec, in the long run it will run bit less often because of the accumulated drift,this will not be problem for the ones that happen on fixed times. This solution skips executions that should have occurred while the program was paused.
2) Keep calculating the expression.nextExecution(executionTime) in a loop and stop if it is after now. This solution skips executions that should have occured while the program was paused.
3) use 1ms if the calculated delay was negative: https://github.com/NoEnv/vertx-cronutils/blob/f200cadcfd826ca48dcf070b5ed8e7cbe5042e3f/src/main/java/com/noenv/cronutils/impl/CronSchedulerImpl.java#L77
This will not skip executions, the missed ones will run in burst until it catches up. 

The 3. solution was chosen for this PR.